### PR TITLE
refactor: v2.5 architecture - delegate classification to AI, add MCP services

### DIFF
--- a/apps/z-stream-analysis/.claude/settings.local.json
+++ b/apps/z-stream-analysis/.claude/settings.local.json
@@ -77,7 +77,8 @@
       "mcp__jira__get_issue_watchers",
       "mcp__jira__list_component_aliases",
       "mcp__jira__add_component_alias",
-      "mcp__jira__remove_component_alias"
+      "mcp__jira__remove_component_alias",
+      "Bash(grep:*)"
     ],
     "deny": []
   }

--- a/apps/z-stream-analysis/README.md
+++ b/apps/z-stream-analysis/README.md
@@ -1,6 +1,6 @@
 # Z-Stream Pipeline Analysis (v2.5)
 
-> **Enterprise Jenkins Pipeline Failure Analysis with 5-Phase Investigation Framework and 286 Unit Tests**
+> **Enterprise Jenkins Pipeline Failure Analysis with 5-Phase Investigation Framework and 279 Unit Tests**
 
 ## What This Does
 
@@ -99,7 +99,7 @@ runs/<job>_<timestamp>/
 └── SUMMARY.txt                 ← Report (created by report.py)
 ```
 
-## Services Layer (12 Python Services)
+## Services Layer (13 Python Service Modules)
 
 | Service | Purpose |
 |---------|---------|
@@ -118,7 +118,7 @@ runs/<job>_<timestamp>/
 
 ## Test Coverage
 
-- **286 unit tests** across 9 test files
+- **279 unit tests** across 8 test files
 - **100% pass rate** with comprehensive edge case coverage
 
 ```bash

--- a/apps/z-stream-analysis/docs/00-OVERVIEW.md
+++ b/apps/z-stream-analysis/docs/00-OVERVIEW.md
@@ -116,7 +116,7 @@ runs/<job>_<timestamp>/
 | `failure_type = element_not_found` | A | AUTOMATION_BUG |
 | Timeout waiting for missing selector | A | AUTOMATION_BUG |
 | Timeout (non-selector) | B1 | INFRASTRUCTURE |
-| `environment.cluster_accessible = false` | B1 | INFRASTRUCTURE |
+| `environment.cluster_connectivity = false` | B1 | INFRASTRUCTURE |
 | Multiple unrelated tests timeout | B1 | INFRASTRUCTURE |
 | 500 errors in console log | B2 | PRODUCT_BUG |
 | Feature story contradicts product behavior | B2/E | PRODUCT_BUG |

--- a/apps/z-stream-analysis/docs/01-STAGE1-DATA-GATHERING.md
+++ b/apps/z-stream-analysis/docs/01-STAGE1-DATA-GATHERING.md
@@ -535,7 +535,7 @@ All collected data is written to the run directory.
     ]
   },
   "environment": {
-    "cluster_accessible": true,
+    "cluster_connectivity": true,
     "environment_score": 0.95
   },
   "console_log": {

--- a/apps/z-stream-analysis/docs/02-STAGE2-AI-ANALYSIS.md
+++ b/apps/z-stream-analysis/docs/02-STAGE2-AI-ANALYSIS.md
@@ -48,7 +48,7 @@ The agent reads `core-data.json` which contains:
 core-data.json
       │
       ├── A1: Environment health check
-      │   environment.cluster_accessible == false?  → ALL TESTS = INFRASTRUCTURE
+      │   environment.cluster_connectivity == false?  → ALL TESTS = INFRASTRUCTURE
       │   environment.environment_score < 0.3?      → ALL TESTS = INFRASTRUCTURE
       │
       ├── A2: Failure pattern detection
@@ -61,7 +61,7 @@ core-data.json
           Same component in multiple errors? → cascading failure candidate
 ```
 
-**Example:** If `environment.environment_score = 0.15` and `cluster_accessible = false`, Phase A short-circuits: all tests classified as INFRASTRUCTURE with confidence 0.95.
+**Example:** If `environment.environment_score = 0.15` and `cluster_connectivity = false`, Phase A short-circuits: all tests classified as INFRASTRUCTURE with confidence 0.95.
 
 ---
 
@@ -180,7 +180,7 @@ C3: Pattern correlation with Phase A
 | Evidence | Classification | Confidence |
 |----------|---------------|------------|
 | >50% tests timeout + env unhealthy | INFRASTRUCTURE | 0.80 |
-| `cluster_accessible=false` | INFRASTRUCTURE | 0.95 |
+| `cluster_connectivity=false` | INFRASTRUCTURE | 0.95 |
 | Multiple unrelated tests timeout | INFRASTRUCTURE | 0.75 |
 
 ### Path B2 — Everything Else (JIRA Investigation)
@@ -277,11 +277,13 @@ E6: Create/link issues (optional)
     "analyzed_at": "2026-02-05T12:30:00Z",
     "analyzer_version": "2.5.0"
   },
+  "investigation_phases_completed": ["A", "B", "C", "D", "E"],
   "per_test_analysis": [
     {
       "test_name": "should create cluster successfully",
       "test_file": "cypress/e2e/cluster/create.cy.ts",
       "classification": "AUTOMATION_BUG",
+      "classification_path": "A",
       "confidence": 0.92,
       "error": {
         "message": "Timed out: Expected to find '#create-btn'",
@@ -320,7 +322,7 @@ E6: Create/link issues (optional)
       "jira_correlation": {
         "search_performed": true,
         "related_issues": [],
-        "feature_story": null
+        "match_confidence": "none"
       }
     }
   ],
@@ -335,7 +337,6 @@ E6: Create/link issues (optional)
       "AUTOMATION_BUG": 2,
       "PRODUCT_BUG": 1
     },
-    "investigation_phases_completed": ["A", "B", "C", "D", "E"],
     "priority_order": [
       {
         "test": "should create cluster successfully",

--- a/apps/z-stream-analysis/docs/04-SERVICES-REFERENCE.md
+++ b/apps/z-stream-analysis/docs/04-SERVICES-REFERENCE.md
@@ -264,7 +264,6 @@ Stage 2 ───── SchemaValidationService ─────── JSON Schem
 | `find_common_dependency(components)` | Find shared dependency root |
 | `get_subsystem_components(subsystem)` | All components in a subsystem |
 | `analyze_failure_impact(components)` | Cascading failure analysis |
-| `build_query_for_phase2(components)` | Generate Cypher queries for Stage 2 |
 
 ---
 

--- a/apps/z-stream-analysis/src/schemas/analysis_results_schema.json
+++ b/apps/z-stream-analysis/src/schemas/analysis_results_schema.json
@@ -160,6 +160,11 @@
             "enum": ["PRODUCT_BUG", "AUTOMATION_BUG", "INFRASTRUCTURE", "MIXED", "UNKNOWN", "NO_BUG", "FLAKY"],
             "description": "Definitive classification of the failure"
           },
+          "classification_path": {
+            "type": "string",
+            "enum": ["A", "B1", "B2"],
+            "description": "Which decision path was used (A=selector mismatch, B1=timeout/infra, B2=JIRA investigation)"
+          },
           "confidence": {
             "type": "number",
             "minimum": 0,
@@ -200,7 +205,7 @@
               "properties": {
                 "classification": {
                   "type": "string",
-                  "enum": ["PRODUCT_BUG", "AUTOMATION_BUG", "INFRASTRUCTURE", "MIXED", "FLAKY"]
+                  "enum": ["PRODUCT_BUG", "AUTOMATION_BUG", "INFRASTRUCTURE", "MIXED", "FLAKY", "UNKNOWN", "NO_BUG"]
                 },
                 "reason": {
                   "type": "string",
@@ -224,12 +229,7 @@
                 }
               }
             ],
-            "description": "Analysis reasoning - can be string or structured object"
-          },
-          "evidence": {
-            "type": "array",
-            "items": { "type": "string" },
-            "description": "Supporting evidence for classification (legacy field)"
+            "description": "Analysis reasoning. Prefer structured object form with summary/evidence/conclusion. String accepted for backward compatibility."
           },
           "root_cause": {
             "type": "string",
@@ -258,7 +258,7 @@
                 }
               }
             ],
-            "description": "Fix recommendation - can be string or structured object"
+            "description": "Fix recommendation. Prefer structured object form with action/steps/owner. String accepted for backward compatibility."
           },
           "jira_correlation": {
             "type": "object",
@@ -316,6 +316,40 @@
               },
               "required": ["classification", "issue"]
             }
+          },
+          "feature_context": {
+            "type": "object",
+            "description": "Feature context from Phase E (Knowledge Graph + JIRA)",
+            "properties": {
+              "subsystem": { "type": "string" },
+              "components_involved": {
+                "type": "array",
+                "items": { "type": "string" }
+              },
+              "feature_story": { "type": "string" },
+              "feature_description": { "type": "string" },
+              "acceptance_criteria_summary": { "type": "string" },
+              "linked_prs": {
+                "type": "array",
+                "items": { "type": "string" }
+              },
+              "por_reference": { "type": ["string", "null"] },
+              "knowledge_graph_context": {
+                "type": "object",
+                "properties": {
+                  "subsystem_queried": { "type": "boolean" },
+                  "component_dependencies": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                  },
+                  "failure_in_dependency": { "type": "boolean" }
+                }
+              },
+              "source": {
+                "type": "string",
+                "description": "How context was obtained (e.g., knowledge_graph+jira, jira_only, knowledge_graph_only)"
+              }
+            }
           }
         }
       }
@@ -330,10 +364,10 @@
         "failed_count": { "type": "integer", "minimum": 0 },
         "total_failures": { "type": "integer", "minimum": 0 },
         "pass_rate": {
-          "oneOf": [
-            { "type": "number", "minimum": 0, "maximum": 100 },
-            { "type": "string" }
-          ]
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100,
+          "description": "Test pass rate as a percentage (0-100)"
         },
         "by_classification": {
           "type": "object",
@@ -430,6 +464,23 @@
           },
           "recommendation": { "type": "string" }
         }
+      }
+    },
+    "feature_context_summary": {
+      "type": "object",
+      "description": "Summary of feature context gathered during Phase E",
+      "properties": {
+        "subsystems_investigated": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "feature_stories_read": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "linked_prs_found": { "type": "integer", "minimum": 0 },
+        "knowledge_graph_queries": { "type": "integer", "minimum": 0 },
+        "jira_feature_queries": { "type": "integer", "minimum": 0 }
       }
     },
     "action_items": {

--- a/apps/z-stream-analysis/src/services/jenkins_intelligence_service.py
+++ b/apps/z-stream-analysis/src/services/jenkins_intelligence_service.py
@@ -68,10 +68,6 @@ class JenkinsTestCaseFailure:
     error_message: Optional[str] = None
     stack_trace: Optional[str] = None  # Full stack trace (no truncation)
     failure_type: Optional[str] = None  # timeout, element_not_found, network, assertion, etc.
-    classification: Optional[str] = None  # PRODUCT_BUG, AUTOMATION_BUG, INFRASTRUCTURE
-    classification_confidence: float = 0.0
-    classification_reasoning: Optional[str] = None
-    recommended_fix: Optional[str] = None
     # Parsed stack trace data
     parsed_stack_trace: Optional[Dict[str, Any]] = None
     root_cause_file: Optional[str] = None
@@ -79,7 +75,7 @@ class JenkinsTestCaseFailure:
     failing_selector: Optional[str] = None
 
 
-# Legacy alias for backward compatibility
+# Short alias used throughout codebase (avoids pytest collection warnings on 'Test' prefix)
 TestCaseFailure = JenkinsTestCaseFailure
 
 
@@ -100,7 +96,7 @@ class JenkinsTestReport:
     duration: float
 
 
-# Legacy alias for backward compatibility
+# Short alias used throughout codebase (avoids pytest collection warnings on 'Test' prefix)
 TestReport = JenkinsTestReport
 
 

--- a/apps/z-stream-analysis/src/services/shared_utils.py
+++ b/apps/z-stream-analysis/src/services/shared_utils.py
@@ -585,7 +585,7 @@ class ServiceBase:
 
 SENSITIVE_PATTERNS = [
     'password', 'token', 'secret', 'key', 'credential',
-    'api_key', 'apikey', 'auth', 'bearer',
+    'api_key', 'apikey', 'api_token', 'apitoken', 'auth', 'bearer',
 ]
 
 

--- a/apps/z-stream-analysis/tests/unit/services/test_knowledge_graph_client.py
+++ b/apps/z-stream-analysis/tests/unit/services/test_knowledge_graph_client.py
@@ -23,7 +23,7 @@ class TestKnowledgeGraphClientInitialization:
         """Test that client initializes without errors."""
         client = KnowledgeGraphClient()
         assert client is not None
-        assert client._mcp_tool_name == 'mcp__user-neo4j-rhacm__read_neo4j_cypher'
+        assert client._mcp_tool_name == 'mcp__neo4j-rhacm__read_neo4j_cypher'
 
     def test_availability_check_caching(self):
         """Test that availability is cached after first check."""
@@ -171,45 +171,6 @@ class TestFailureImpactAnalysis:
         assert len(result['recommendations']) > 0
 
 
-class TestQueryBuilding:
-    """Test Cypher query building for Phase 2."""
-
-    def setup_method(self):
-        """Set up test fixtures."""
-        self.client = KnowledgeGraphClient()
-
-    def test_build_query_for_phase2_single_component(self):
-        """Test building queries for a single component."""
-        queries = self.client.build_query_for_phase2(['search-api'])
-
-        assert 'dependents_search-api' in queries
-        assert 'info_search-api' in queries
-        assert 'DEPENDS_ON' in queries['dependents_search-api']
-        assert 'search-api' in queries['dependents_search-api']
-
-    def test_build_query_for_phase2_multiple_components(self):
-        """Test building queries for multiple components."""
-        queries = self.client.build_query_for_phase2(['search-api', 'console'])
-
-        assert 'dependents_search-api' in queries
-        assert 'dependents_console' in queries
-        assert 'common_dependency' in queries
-
-    def test_build_query_for_phase2_limits_to_five(self):
-        """Test that query building limits to 5 components."""
-        components = [f'comp-{i}' for i in range(10)]
-        queries = self.client.build_query_for_phase2(components)
-
-        # Should have queries for first 5 components only
-        dependents_keys = [k for k in queries.keys() if k.startswith('dependents_')]
-        assert len(dependents_keys) <= 5
-
-    def test_build_query_for_phase2_empty_list(self):
-        """Test building queries with empty list."""
-        queries = self.client.build_query_for_phase2([])
-        assert queries == {}
-
-
 class TestCacheManagement:
     """Test cache management functionality."""
 
@@ -276,72 +237,24 @@ class TestDataClasses:
         assert 'Console' in chain.subsystems_affected
 
 
-class TestCypherQueryGeneration:
-    """Test that generated Cypher queries are syntactically valid."""
-
-    def setup_method(self):
-        """Set up test fixtures."""
-        self.client = KnowledgeGraphClient()
-
-    def test_dependents_query_syntax(self):
-        """Test that dependents query has valid Cypher syntax."""
-        queries = self.client.build_query_for_phase2(['search-api'])
-        query = queries['dependents_search-api']
-
-        # Check for required Cypher elements
-        assert 'MATCH' in query
-        assert 'RETURN' in query
-        assert ':RHACMComponent' in query
-        assert ':DEPENDS_ON' in query
-        assert 'WHERE' in query
-
-    def test_info_query_syntax(self):
-        """Test that info query has valid Cypher syntax."""
-        queries = self.client.build_query_for_phase2(['search-api'])
-        query = queries['info_search-api']
-
-        assert 'MATCH' in query
-        assert 'RETURN' in query
-        assert 'LIMIT 1' in query
-
-    def test_common_dependency_query_syntax(self):
-        """Test that common dependency query has valid Cypher syntax."""
-        queries = self.client.build_query_for_phase2(['comp1', 'comp2'])
-        query = queries['common_dependency']
-
-        assert 'MATCH' in query
-        assert 'WITH' in query
-        assert 'count' in query.lower()
-        assert 'ORDER BY' in query
-
-
 class TestIntegrationWithComponentExtractor:
     """Test integration patterns with ComponentExtractor."""
 
-    def test_workflow_component_to_graph_query(self):
-        """Test the typical workflow from extraction to query building."""
+    def test_workflow_component_extraction(self):
+        """Test component extraction from error messages."""
         from src.services.component_extractor import ComponentExtractor
 
-        # Step 1: Extract components from error
         extractor = ComponentExtractor()
         error = "search-api returned 500, grc-policy-propagator timed out"
         components = extractor.extract_from_error(error)
 
         assert len(components) == 2
 
-        # Step 2: Build queries for Knowledge Graph
-        client = KnowledgeGraphClient()
-        queries = client.build_query_for_phase2(components)
-
-        # Should have queries for both components
-        assert len(queries) >= 4  # 2 components x 2 queries each + common_dependency
-
     def test_workflow_with_subsystem_context(self):
-        """Test adding subsystem context to query results."""
+        """Test adding subsystem context to extracted components."""
         from src.services.component_extractor import ComponentExtractor
 
         extractor = ComponentExtractor()
-        client = KnowledgeGraphClient()
 
         # Extract component
         components = extractor.extract_from_error("search-api error")
@@ -350,7 +263,3 @@ class TestIntegrationWithComponentExtractor:
         for comp in components:
             subsystem = extractor.get_subsystem(comp)
             assert subsystem == 'Search'
-
-        # Build queries
-        queries = client.build_query_for_phase2(components)
-        assert 'dependents_search-api' in queries


### PR DESCRIPTION
## Summary
- Major architectural refactoring: remove Python classification services, delegate all classification to AI agent
- Add 5 new MCP-integrated services (acm_console_knowledge, knowledge_graph_client, component_extractor, jenkins_api_client, acm_ui_mcp_client)
- Expand gather.py with richer factual data collection
- Replace monolithic docs with modular numbered docs (00-05)
- Add mcp/ directory with server configs for acm-ui, jira, neo4j-rhacm, polarion
- Clean up ~59K lines of legacy code (concepts/, shared/, old docs, test-generator)
- Refine agent instructions, schema enhancements, and doc cleanup

Made with [Cursor](https://cursor.com)